### PR TITLE
Allow both ways of version tagging on CMS recipe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require":
   {
-    "silverstripe/recipe-cms": "^1"
+    "silverstripe/recipe-cms": "^1 || ^4"
   },
   "require-dev": {
     "phpunit/PHPUnit": "^5.7",


### PR DESCRIPTION
The silverstripe/recipe-cms has two lines of tags, both covering SS 4.x, this update enables to install this module with both.