### PR TITLE
PHP 8.1 compatibility changes

### DIFF
--- a/src/Models/PageFeedbackEntry.php
+++ b/src/Models/PageFeedbackEntry.php
@@ -66,7 +66,7 @@ class PageFeedbackEntry extends DataObject
      */
     public function getDisplayComment()
     {
-        if (strlen($this->Comment)) {
+        if ($this->Comment) {
             return $this->Comment;
         }
 


### PR DESCRIPTION
**Fixes Issue:** `[Deprecated] strlen(): Passing null to parameter #1 ($string) of type string is deprecated`